### PR TITLE
Framework compatibility

### DIFF
--- a/Classes/FontAwesome.swift
+++ b/Classes/FontAwesome.swift
@@ -22,14 +22,14 @@
 
 import UIKit
 
-extension UIFont {
-  class func fontAwesomeOfSize(fontSize: CGFloat) -> UIFont {
+public extension UIFont {
+  public class func fontAwesomeOfSize(fontSize: CGFloat) -> UIFont {
     return UIFont(name: "FontAwesome", size: fontSize)!
   }
 }
 
-extension String {
-  static func fontAwesomeIconWithName(name: String) -> String {
+public extension String {
+  public static func fontAwesomeIconWithName(name: String) -> String {
     var icons: [String: String]?
     var token: dispatch_once_t = 0
     

--- a/Classes/FontAwesome.swift
+++ b/Classes/FontAwesome.swift
@@ -21,11 +21,40 @@
 // THE SOFTWARE.
 
 import UIKit
+import CoreText
+
+private class FontLoader {
+    class func loadFont(name: String) {
+        let bundleURL = NSBundle(forClass: self).URLForResource("FontAwesome.swift", withExtension: "bundle")
+        let bundle = NSBundle(URL: bundleURL!)
+        let fontURL = bundle?.URLForResource(name, withExtension: "otf")
+        
+        let data = NSData(contentsOfURL: fontURL!)!
+        
+        let provider = CGDataProviderCreateWithCFData(data)
+        let font = CGFontCreateWithDataProvider(provider)!
+        
+        var error: Unmanaged<CFError>?
+        if !CTFontManagerRegisterGraphicsFont(font, &error) {
+            let errorDescription: CFStringRef = CFErrorCopyDescription(error!.takeUnretainedValue())
+            let nsError = error!.takeUnretainedValue() as AnyObject as NSError
+            NSException(name: NSInternalInconsistencyException, reason: errorDescription, userInfo: [NSUnderlyingErrorKey: nsError]).raise()
+        }
+    }
+}
 
 public extension UIFont {
-  public class func fontAwesomeOfSize(fontSize: CGFloat) -> UIFont {
-    return UIFont(name: "FontAwesome", size: fontSize)!
-  }
+    public class func fontAwesomeOfSize(fontSize: CGFloat) -> UIFont {
+        struct Static {
+            static var onceToken : dispatch_once_t = 0
+        }
+        
+        let name = "FontAwesome"
+        dispatch_once(&Static.onceToken) {
+            FontLoader.loadFont("FontAwesome")
+        }
+        return UIFont(name: name, size: fontSize)!
+    }
 }
 
 public extension String {

--- a/FontAwesome.swift.podspec
+++ b/FontAwesome.swift.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.source_files = 'Classes/*.{swift}'
+  s.resource_bundle = { 'FontAwesome.swift' => 'Resources/*.otf' }
 end


### PR DESCRIPTION
This PR does 3 things:

1. Updates the podspec so the font file is added to a bundle and import the needed frameworks (UIKit and CoreText)
2. Changes some stuff's visibility to public, so they can be accessed from another framework
3. Dynamically loads the font, so the developer doesn't add it manually to the project and to Info.plist. Honestly, I don't even know if that would work when you're creating it (with `UIFont(name:, size:)`) from another framework.

Those steps were needed to ensure compatibility to the upcoming CocoaPods 0.36, which adds support to dynamic frameworks.