### PR TITLE
Change class to use constants instead of string literals

### DIFF
--- a/Classes/FontAwesome.swift
+++ b/Classes/FontAwesome.swift
@@ -656,9 +656,6 @@ public enum FontAwesome: String {
 
 public extension String {
     public static func fontAwesomeIconWithName(name: FontAwesome) -> String {
-        var icons: [String: String]?
-        var token: dispatch_once_t = 0
-        
         return name.rawValue.substringToIndex(advance(name.rawValue.startIndex, 1))
     }
 }

--- a/Classes/FontAwesome.swift
+++ b/Classes/FontAwesome.swift
@@ -59,613 +59,606 @@ public extension UIFont {
   }
 }
 
+public enum FontAwesome: String {
+    case Adjust = "\u{f042}"
+    case ADN = "\u{f170}"
+    case AlignCenter = "\u{f037}"
+    case AlignJustify = "\u{f039}"
+    case AlignLeft = "\u{f036}"
+    case AlignRight = "\u{f038}"
+    case Ambulance = "\u{f0f9}"
+    case Anchor = "\u{f13d}"
+    case Android = "\u{f17b}"
+    case Angellist = "\u{f209}"
+    case AngleDoubleDown = "\u{f103}"
+    case AngleDoubleLeft = "\u{f100}"
+    case AngleDoubleRight = "\u{f101}"
+    case AngleDoubleUp = "\u{f102}"
+    case AngleDown = "\u{f107}"
+    case AngleLeft = "\u{f104}"
+    case AngleRight = "\u{f105}"
+    case AngleUp = "\u{f106}"
+    case Apple = "\u{f179}"
+    case Archive = "\u{f187}"
+    case AreaChart = "\u{f1fe}"
+    case ArrowCircleDown = "\u{f0ab}"
+    case ArrowCircleLeft = "\u{f0a8}"
+    case ArrowCircleODown = "\u{f01a}"
+    case ArrowCircleOLeft = "\u{f190}"
+    case ArrowCircleORight = "\u{f18e}"
+    case ArrowCircleOUp = "\u{f01b}"
+    case ArrowCircleRight = "\u{f0a9}"
+    case ArrowCircleUp = "\u{f0aa}"
+    case ArrowDown = "\u{f063}"
+    case ArrowLeft = "\u{f060}"
+    case ArrowRight = "\u{f061}"
+    case ArrowUp = "\u{f062}"
+    case Arrows = "\u{f047}"
+    case ArrowsAlt = "\u{f0b2}"
+    case ArrowsH = "\u{f07e}"
+    case ArrowsV = "\u{f07d}"
+    case Asterisk = "\u{f069}"
+    case At = "\u{f1fa}"
+    case Automobile = "\u{f1b9}"
+    case Backward = "\u{f04a}"
+    case Ban = "\u{f05e}"
+    case Bank = "\u{f19c}"
+    case BarChart = "\u{f080}"
+    case BarChartO = "\u{f080}A"
+    case Barcode = "\u{f02a}"
+    case Bars = "\u{f0c9}"
+    case Bed = "\u{f236}"
+    case Beer = "\u{f0fc}"
+    case Behance = "\u{f1b4}"
+    case BehanceSquare = "\u{f1b5}"
+    case Bell = "\u{f0f3}"
+    case BellO = "\u{f0a2}"
+    case BellSlash = "\u{f1f6}"
+    case BellSlashO = "\u{f1f7}"
+    case Bicycle = "\u{f206}"
+    case Binoculars = "\u{f1e5}"
+    case BirthdayCake = "\u{f1fd}"
+    case Bitbucket = "\u{f171}"
+    case BitbucketSquare = "\u{f172}"
+    case Bitcoin = "\u{f15a}"
+    case Bold = "\u{f032}"
+    case Bolt = "\u{f0e7}"
+    case Bomb = "\u{f1e2}"
+    case Book = "\u{f02d}"
+    case Bookmark = "\u{f02e}"
+    case BookmarkO = "\u{f097}"
+    case Briefcase = "\u{f0b1}"
+    case Btc = "\u{f15a}A"
+    case Bug = "\u{f188}"
+    case Building = "\u{f1ad}"
+    case BuildingO = "\u{f0f7}"
+    case Bullhorn = "\u{f0a1}"
+    case Bullseye = "\u{f140}"
+    case Bus = "\u{f207}"
+    case Buysellads = "\u{f20d}"
+    case Cab = "\u{f1ba}"
+    case Calculator = "\u{f1ec}"
+    case Calendar = "\u{f073}"
+    case CalendarO = "\u{f133}"
+    case Camera = "\u{f030}"
+    case CameraRetro = "\u{f083}"
+    case Car = "\u{f1b9}A"
+    case CaretDown = "\u{f0d7}"
+    case CaretLeft = "\u{f0d9}"
+    case CaretRight = "\u{f0da}"
+    case CaretSquareODown = "\u{f150}"
+    case CaretSquareOLeft = "\u{f191}"
+    case CaretSquareORight = "\u{f152}"
+    case CaretSquareOUp = "\u{f151}"
+    case CaretUp = "\u{f0d8}"
+    case CartArrowDown = "\u{f218}"
+    case CartPlus = "\u{f217}"
+    case Cc = "\u{f20a}"
+    case CCAmex = "\u{f1f3}"
+    case CCDiscover = "\u{f1f2}"
+    case CCMastercard = "\u{f1f1}"
+    case CCPaypal = "\u{f1f4}"
+    case CCStripe = "\u{f1f5}"
+    case CCVisa = "\u{f1f0}"
+    case Certificate = "\u{f0a3}"
+    case Chain = "\u{f0c1}"
+    case ChainBroken = "\u{f127}"
+    case Check = "\u{f00c}"
+    case CheckCircle = "\u{f058}"
+    case CheckCircleO = "\u{f05d}"
+    case CheckSquare = "\u{f14a}"
+    case CheckSquareO = "\u{f046}"
+    case ChevronCircleDown = "\u{f13a}"
+    case ChevronCircleLeft = "\u{f137}"
+    case ChevronCircleRight = "\u{f138}"
+    case ChevronCircleUp = "\u{f139}"
+    case ChevronDown = "\u{f078}"
+    case ChevronLeft = "\u{f053}"
+    case ChevronRight = "\u{f054}"
+    case ChevronUp = "\u{f077}"
+    case Child = "\u{f1ae}"
+    case Circle = "\u{f111}"
+    case CircleO = "\u{f10c}"
+    case CircleONotch = "\u{f1ce}"
+    case CircleThin = "\u{f1db}"
+    case Clipboard = "\u{f0ea}"
+    case ClockO = "\u{f017}"
+    case Close = "\u{f00d}"
+    case Cloud = "\u{f0c2}"
+    case CloudDownload = "\u{f0ed}"
+    case CloudUpload = "\u{f0ee}"
+    case CNY = "\u{f157}"
+    case Code = "\u{f121}"
+    case CodeFork = "\u{f126}"
+    case Codepen = "\u{f1cb}"
+    case Coffee = "\u{f0f4}"
+    case Cog = "\u{f013}"
+    case Cogs = "\u{f085}"
+    case Columns = "\u{f0db}"
+    case Comment = "\u{f075}"
+    case CommentO = "\u{f0e5}"
+    case Comments = "\u{f086}"
+    case CommentsO = "\u{f0e6}"
+    case Compass = "\u{f14e}"
+    case Compress = "\u{f066}"
+    case Connectdevelop = "\u{f20e}"
+    case Copy = "\u{f0c5}"
+    case Copyright = "\u{f1f9}"
+    case CreditCard = "\u{f09d}"
+    case Crop = "\u{f125}"
+    case Crosshairs = "\u{f05b}"
+    case Css3 = "\u{f13c}"
+    case Cube = "\u{f1b2}"
+    case Cubes = "\u{f1b3}"
+    case Cut = "\u{f0c4}"
+    case Cutlery = "\u{f0f5}"
+    case Dashboard = "\u{f0e4}"
+    case Dashcube = "\u{f210}"
+    case Database = "\u{f1c0}"
+    case Dedent = "\u{f03b}"
+    case Delicious = "\u{f1a5}"
+    case Desktop = "\u{f108}"
+    case Deviantart = "\u{f1bd}"
+    case Diamond = "\u{f219}"
+    case Digg = "\u{f1a6}"
+    case Dollar = "\u{f155}"
+    case DotCircleO = "\u{f192}"
+    case Download = "\u{f019}"
+    case Dribbble = "\u{f17d}"
+    case Dropbox = "\u{f16b}"
+    case Drupal = "\u{f1a9}"
+    case Edit = "\u{f044}"
+    case Eject = "\u{f052}"
+    case EllipsisH = "\u{f141}"
+    case EllipsisV = "\u{f142}"
+    case Empire = "\u{f1d1}"
+    case Envelope = "\u{f0e0}"
+    case EnvelopeO = "\u{f003}"
+    case EnvelopeSquare = "\u{f199}"
+    case Eraser = "\u{f12d}"
+    case EUR = "\u{f153}"
+    case Euro = "\u{f153}A"
+    case Exchange = "\u{f0ec}"
+    case Exclamation = "\u{f12a}"
+    case ExclamationCircle = "\u{f06a}"
+    case ExclamationTriangle = "\u{f071}"
+    case Expand = "\u{f065}"
+    case ExternalLink = "\u{f08e}"
+    case ExternalLinkSquare = "\u{f14c}"
+    case Eye = "\u{f06e}"
+    case EyeSlash = "\u{f070}"
+    case Eyedropper = "\u{f1fb}"
+    case Facebook = "\u{f09a}"
+    case FacebookF = "\u{f09a}A"
+    case FacebookOfficial = "\u{f230}"
+    case FacebookSquare = "\u{f082}"
+    case FastBackward = "\u{f049}"
+    case FastForward = "\u{f050}"
+    case Fax = "\u{f1ac}"
+    case Female = "\u{f182}"
+    case FighterJet = "\u{f0fb}"
+    case File = "\u{f15b}"
+    case FileArchiveO = "\u{f1c6}"
+    case FileAudioO = "\u{f1c7}"
+    case FileCodeO = "\u{f1c9}"
+    case FileExcelO = "\u{f1c3}"
+    case FileImageO = "\u{f1c5}"
+    case FileMoviO = "\u{f1c8}"
+    case FileO = "\u{f016}"
+    case FilePdfO = "\u{f1c1}"
+    case FilePhotoO = "\u{f1c5}A"
+    case FilePictureO = "\u{f1c5}B"
+    case FilePowerpointO = "\u{f1c4}"
+    case FileSoundO = "\u{f1c7}A"
+    case FileText = "\u{f15c}"
+    case FileTextO = "\u{f0f6}"
+    case FileVideoO = "\u{f1c8}A"
+    case FileWordO = "\u{f1c2}"
+    case FileZipO = "\u{f1c6}A"
+    case FilesO = "\u{f0c5}A"
+    case Film = "\u{f008}"
+    case Filter = "\u{f0b0}"
+    case Fire = "\u{f06d}"
+    case FireExtinguisher = "\u{f134}"
+    case Flag = "\u{f024}"
+    case FlagCheckered = "\u{f11e}"
+    case FlagO = "\u{f11d}"
+    case Flash = "\u{f0e7}A"
+    case Flask = "\u{f0c3}"
+    case Flickr = "\u{f16e}"
+    case FloppyO = "\u{f0c7}"
+    case Folder = "\u{f07b}"
+    case FolderO = "\u{f114}"
+    case FolderOpen = "\u{f07c}"
+    case FolderOpenO = "\u{f115}"
+    case Font = "\u{f031}"
+    case Forumbee = "\u{f211}"
+    case Forward = "\u{f04e}"
+    case Foursquare = "\u{f180}"
+    case FrownO = "\u{f119}"
+    case FutbolO = "\u{f1e3}"
+    case Gamepad = "\u{f11b}"
+    case Gavel = "\u{f0e3}"
+    case Gbp = "\u{f154}"
+    case Ge = "\u{f1d1}A"
+    case Gear = "\u{f013}A"
+    case Gears = "\u{f085}A"
+    case Genderless = "\u{f1db}A"
+    case Gift = "\u{f06b}"
+    case Git = "\u{f1d3}"
+    case GitSquare = "\u{f1d2}"
+    case Github = "\u{f09b}"
+    case GithubAlt = "\u{f113}"
+    case GithubSquare = "\u{f092}"
+    case Gittip = "\u{f184}"
+    case Glass = "\u{f000}"
+    case Globe = "\u{f0ac}"
+    case Google = "\u{f1a0}"
+    case GooglePlus = "\u{f0d5}"
+    case GooglePlusSquare = "\u{f0d4}"
+    case GoogleWallet = "\u{f1ee}"
+    case GraduationCap = "\u{f19d}"
+    case Gratipay = "\u{f184}A"
+    case Group = "\u{f0c0}"
+    case HSquare = "\u{f0fd}"
+    case HackerNews = "\u{f1d4}"
+    case HandODown = "\u{f0a7}"
+    case HandOLeft = "\u{f0a5}"
+    case HandORight = "\u{f0a4}"
+    case HandOUp = "\u{f0a6}"
+    case HddO = "\u{f0a0}"
+    case Header = "\u{f1dc}"
+    case Headphones = "\u{f025}"
+    case Heart = "\u{f004}"
+    case HeartO = "\u{f08a}"
+    case Heartbeat = "\u{f21e}"
+    case History = "\u{f1da}"
+    case Home = "\u{f015}"
+    case HospitalO = "\u{f0f8}"
+    case Hotel = "\u{f236}A"
+    case Html5 = "\u{f13b}"
+    case Ils = "\u{f20b}"
+    case Image = "\u{f03e}"
+    case Inbox = "\u{f01c}"
+    case Indent = "\u{f03c}"
+    case Info = "\u{f129}"
+    case InfoCircle = "\u{f05a}"
+    case Inr = "\u{f156}"
+    case Instagram = "\u{f16d}"
+    case Institution = "\u{f19c}A"
+    case Ioxhost = "\u{f208}"
+    case Italic = "\u{f033}"
+    case Joomla = "\u{f1aa}"
+    case JPY = "\u{f157}A"
+    case Jsfiddle = "\u{f1cc}"
+    case Key = "\u{f084}"
+    case KeyboardO = "\u{f11c}"
+    case Krw = "\u{f159}"
+    case Language = "\u{f1ab}"
+    case Laptop = "\u{f109}"
+    case LastFM = "\u{f202}"
+    case LastFMSquare = "\u{f203}"
+    case Leaf = "\u{f06c}"
+    case Leanpub = "\u{f212}"
+    case Legal = "\u{f0e3}A"
+    case LemonO = "\u{f094}"
+    case LevelDown = "\u{f149}"
+    case LevelUp = "\u{f148}"
+    case LifeBouy = "\u{f1cd}"
+    case LifeBuoy = "\u{f1cd}A"
+    case LifeRing = "\u{f1cd}B"
+    case LifeSaver = "\u{f1cd}C"
+    case LightbulbO = "\u{f0eb}"
+    case LineChart = "\u{f201}"
+    case Link = "\u{f0c1}A"
+    case LinkedIn = "\u{f0e1}"
+    case LinkedInSquare = "\u{f08c}"
+    case Linux = "\u{f17c}"
+    case List = "\u{f03a}"
+    case ListAlt = "\u{f022}"
+    case ListOL = "\u{f0cb}"
+    case ListUL = "\u{f0ca}"
+    case LocationArrow = "\u{f124}"
+    case Lock = "\u{f023}"
+    case LongArrowDown = "\u{f175}"
+    case LongArrowLeft = "\u{f177}"
+    case LongArrowRight = "\u{f178}"
+    case LongArrowUp = "\u{f176}"
+    case Magic = "\u{f0d0}"
+    case Magnet = "\u{f076}"
+    case MailForward = "\u{f064}"
+    case MailReply = "\u{f112}"
+    case MailReplyAll  = "\u{f122}"
+    case Male = "\u{f183}"
+    case MapMarker = "\u{f041}"
+    case Mars = "\u{f222}"
+    case MarsDouble = "\u{f227}"
+    case MarsStroke = "\u{f229}"
+    case MarsStrokeH = "\u{f22b}"
+    case MarsStrokeV = "\u{f22a}"
+    case Maxcdn = "\u{f136}"
+    case Meanpath = "\u{f20c}"
+    case Medium = "\u{f23a}"
+    case Medkit = "\u{f0fa}"
+    case MehO = "\u{f11a}"
+    case Mercury = "\u{f223}"
+    case Microphone = "\u{f130}"
+    case MicrophoneSlash = "\u{f131}"
+    case Minus = "\u{f068}"
+    case MinusCircle = "\u{f056}"
+    case MinusSquare = "\u{f146}"
+    case MinusSquareO = "\u{f147}"
+    case Mobile = "\u{f10b}"
+    case MobilePhone = "\u{f10b}A"
+    case Money = "\u{f0d6}"
+    case MoonO = "\u{f186}"
+    case MortarBoard = "\u{f19d}A"
+    case Motorcycle = "\u{f21c}"
+    case Music = "\u{f001}"
+    case Navicon = "\u{f0c9}A"
+    case Neuter = "\u{f22c}"
+    case NewspaperO = "\u{f1ea}"
+    case Openid = "\u{f19b}"
+    case Outdent = "\u{f03b}A"
+    case Pagelines = "\u{f18c}"
+    case PaintBrush = "\u{f1fc}"
+    case PaperPlane = "\u{f1d8}"
+    case PaperPlaneO = "\u{f1d9}"
+    case Paperclip = "\u{f0c6}"
+    case Paragraph = "\u{f1dd}"
+    case Paste = "\u{f0ea}A"
+    case Pause = "\u{f04c}"
+    case Paw = "\u{f1b0}"
+    case Paypal = "\u{f1ed}"
+    case Pencil = "\u{f040}"
+    case PencilSquare = "\u{f14b}"
+    case PencilSquareO = "\u{f044}A"
+    case Phone = "\u{f095}"
+    case PhoneSquare = "\u{f098}"
+    case Photo = "\u{f03e}A"
+    case PictureO = "\u{f03e}B"
+    case PieChart = "\u{f200}"
+    case PiedPiper = "\u{f1a7}"
+    case PiedPiperAlt = "\u{f1a8}"
+    case Pinterest = "\u{f0d2}"
+    case PinterestP = "\u{f231}"
+    case PinterestSquare = "\u{f0d3}"
+    case Plane = "\u{f072}"
+    case Play = "\u{f04b}"
+    case PlayCircle = "\u{f144}"
+    case PlayCircleO = "\u{f01d}"
+    case Plug = "\u{f1e6}"
+    case Plus = "\u{f067}"
+    case PlusCircle = "\u{f055}"
+    case PlusSquare = "\u{f0fe}"
+    case PlusSquareO = "\u{f196}"
+    case PowerOff = "\u{f011}"
+    case Print = "\u{f02f}"
+    case PuzzlePiece = "\u{f12e}"
+    case Qq = "\u{f1d6}"
+    case Qrcode = "\u{f029}"
+    case Question = "\u{f128}"
+    case QuestionCircle = "\u{f059}"
+    case QuoteLeft = "\u{f10d}"
+    case QuoteRight = "\u{f10e}"
+    case Ra = "\u{f1d0}"
+    case Random = "\u{f074}"
+    case Rebel = "\u{f1d0}A"
+    case Recycle = "\u{f1b8}"
+    case Reddit = "\u{f1a1}"
+    case RedditSquare = "\u{f1a2}"
+    case Refresh = "\u{f021}"
+    case Remove = "\u{f00d}A"
+    case Renren = "\u{f18b}"
+    case Reorder = "\u{f0c9}B"
+    case Repeat = "\u{f01e}"
+    case Reply = "\u{f112}A"
+    case ReplyAll = "\u{f122}A"
+    case Retweet = "\u{f079}"
+    case RMB = "\u{f157}B"
+    case Road = "\u{f018}"
+    case Rocket = "\u{f135}"
+    case RotateLeft = "\u{f0e2}"
+    case RotateRight = "\u{f01e}A"
+    case Rouble = "\u{f158}"
+    case Rss = "\u{f09e}"
+    case RssSquare = "\u{f143}"
+    case RUB = "\u{f158}A"
+    case Ruble = "\u{f158}B"
+    case Rupee = "\u{f156}A"
+    case Save = "\u{f0c7}A"
+    case Scissors = "\u{f0c4}A"
+    case Search = "\u{f002}"
+    case SearchMinus = "\u{f010}"
+    case SearchPlus = "\u{f00e}"
+    case Sellsy = "\u{f213}"
+    case Send = "\u{f1d8}A"
+    case SendO = "\u{f1d9}A"
+    case Server = "\u{f233}"
+    case Share = "\u{f064}A"
+    case ShareAlt = "\u{f1e0}"
+    case ShareAltSquare = "\u{f1e1}"
+    case ShareSquare = "\u{f14d}"
+    case ShareSquareO = "\u{f045}"
+    case Shekel = "\u{f20b}A"
+    case Sheqel = "\u{f20b}B"
+    case Shield = "\u{f132}"
+    case Ship = "\u{f21a}"
+    case Shirtsinbulk = "\u{f214}"
+    case ShoppingCart = "\u{f07a}"
+    case SignIn = "\u{f090}"
+    case SignOut = "\u{f08b}"
+    case Signal = "\u{f012}"
+    case Simplybuilt = "\u{f215}"
+    case Sitemap = "\u{f0e8}"
+    case Skyatlas = "\u{f216}"
+    case Skype = "\u{f17e}"
+    case Slack = "\u{f198}"
+    case Sliders = "\u{f1de}"
+    case Slideshare = "\u{f1e7}"
+    case SmileO = "\u{f118}"
+    case SoccerBallO  = "\u{f1e3}A"
+    case Sort = "\u{f0dc}"
+    case SortAlphaAsc = "\u{f15d}"
+    case SortAlphaDesc = "\u{f15e}"
+    case SortAmountAsc = "\u{f160}"
+    case SortAmountDesc = "\u{f161}"
+    case SortAsc = "\u{f0de}"
+    case SortDesc = "\u{f0dd}"
+    case SortDown  = "\u{f0dd}A"
+    case SortNumericAsc = "\u{f162}"
+    case SortNumericDesc = "\u{f163}"
+    case SortUp = "\u{f0de}A"
+    case SoundCloud = "\u{f1be}"
+    case SpaceShuttle = "\u{f197}"
+    case Spinner = "\u{f110}"
+    case Spoon = "\u{f1b1}"
+    case Spotify = "\u{f1bc}"
+    case Square = "\u{f0c8}"
+    case SquareO = "\u{f096}"
+    case StackExchange = "\u{f18d}"
+    case StackOverflow = "\u{f16c}"
+    case Star = "\u{f005}"
+    case StarHalf = "\u{f089}"
+    case StarHalfEmpty = "\u{f123}"
+    case StarHalfFull = "\u{f123}A"
+    case StarHalfO = "\u{f123}B"
+    case StarO = "\u{f006}"
+    case Steam = "\u{f1b6}"
+    case SteamSquare = "\u{f1b7}"
+    case StepBackward = "\u{f048}"
+    case StepForward = "\u{f051}"
+    case Stethoscope = "\u{f0f1}"
+    case Stop = "\u{f04d}"
+    case StreetView = "\u{f21d}"
+    case Strikethrough = "\u{f0cc}"
+    case StumbleUpon = "\u{f1a4}"
+    case StumbleUponCircle = "\u{f1a3}"
+    case Subscript = "\u{f12c}"
+    case Subway = "\u{f239}"
+    case Suitcase = "\u{f0f2}"
+    case SunO = "\u{f185}"
+    case Superscript = "\u{f12b}"
+    case Support = "\u{f1cd}D"
+    case Table = "\u{f0ce}"
+    case Tablet = "\u{f10a}"
+    case Tachometer = "\u{f0e4}A"
+    case Tag = "\u{f02b}"
+    case Tags = "\u{f02c}"
+    case Tasks = "\u{f0ae}"
+    case Taxi = "\u{f1ba}A"
+    case TencentWeibo = "\u{f1d5}"
+    case Terminal = "\u{f120}"
+    case TextHeight = "\u{f034}"
+    case TextWidth = "\u{f035}"
+    case Th = "\u{f00a}"
+    case ThLarge = "\u{f009}"
+    case ThList = "\u{f00b}"
+    case ThumbTack = "\u{f08d}"
+    case ThumbsDown = "\u{f165}"
+    case ThumbsODown = "\u{f088}"
+    case ThumbsOUp = "\u{f087}"
+    case ThumbsUp = "\u{f164}"
+    case Ticket = "\u{f145}"
+    case Times = "\u{f00d}B"
+    case TimesCircle = "\u{f057}"
+    case TimesCircleO = "\u{f05c}"
+    case Tint = "\u{f043}"
+    case ToggleDown = "\u{f150}A"
+    case ToggleLeft = "\u{f191}A"
+    case ToggleOff = "\u{f204}"
+    case ToggleOn = "\u{f205}"
+    case ToggleRight = "\u{f152}A"
+    case ToggleUp = "\u{f151}A"
+    case Train = "\u{f238}"
+    case TransGender = "\u{f224}"
+    case TransGenderAlt = "\u{f225}"
+    case Trash = "\u{f1f8}"
+    case TrashO = "\u{f014}"
+    case Tree = "\u{f1bb}"
+    case Trello = "\u{f181}"
+    case Trophy = "\u{f091}"
+    case Truck = "\u{f0d1}"
+    case Try = "\u{f195}"
+    case Tty = "\u{f1e4}"
+    case Tumblr = "\u{f173}"
+    case TumblrSquare = "\u{f174}"
+    case TurkishLira  = "\u{f195}A"
+    case Twitch = "\u{f1e8}"
+    case Twitter = "\u{f099}"
+    case TwitterSquare = "\u{f081}"
+    case Umbrella = "\u{f0e9}"
+    case Underline = "\u{f0cd}"
+    case Undo = "\u{f0e2}A"
+    case University = "\u{f19c}B"
+    case Unlink = "\u{f127}A"
+    case Unlock = "\u{f09c}"
+    case UnlockAlt = "\u{f13e}"
+    case Unsorted = "\u{f0dc}A"
+    case Upload = "\u{f093}"
+    case USD = "\u{f155}A"
+    case User = "\u{f007}"
+    case UserMd = "\u{f0f0}"
+    case UserPlus = "\u{f234}"
+    case UserSecret = "\u{f21b}"
+    case UserTimes = "\u{f235}"
+    case Users = "\u{f0c0}A"
+    case Venus = "\u{f221}"
+    case VenusDouble = "\u{f226}"
+    case VenusMars = "\u{f228}"
+    case Viacoin = "\u{f237}"
+    case VideoCamera = "\u{f03d}"
+    case VimeoSquare = "\u{f194}"
+    case Vine = "\u{f1ca}"
+    case Vk = "\u{f189}"
+    case VolumeDown = "\u{f027}"
+    case VolumeOff = "\u{f026}"
+    case VolumeUp = "\u{f028}"
+    case Warning = "\u{f071}A"
+    case Wechat = "\u{f1d7}"
+    case Weibo = "\u{f18a}"
+    case Weixin = "\u{f1d7}A"
+    case Whatsapp = "\u{f232}"
+    case Wheelchair = "\u{f193}"
+    case Wifi = "\u{f1eb}"
+    case Windows = "\u{f17a}"
+    case WON = "\u{f159}A"
+    case Wordpress = "\u{f19a}"
+    case Wrench = "\u{f0ad}"
+    case Xing = "\u{f168}"
+    case XingSquare = "\u{f169}"
+    case Yahoo = "\u{f19e}"
+    case Yelp = "\u{f1e9}"
+    case Yen = "\u{f157}C"
+    case Youtube = "\u{f167}"
+    case YoutubePlay = "\u{f16a}"
+}
+
 public extension String {
-  public static func fontAwesomeIconWithName(name: String) -> String {
-    var icons: [String: String]?
-    var token: dispatch_once_t = 0
-    
-    dispatch_once(&token) {
-      icons = [
-        "fa-adjust":"\u{f042}",
-        "fa-adn":"\u{f170}",
-        "fa-align-center":"\u{f037}",
-        "fa-align-justify":"\u{f039}",
-        "fa-align-left":"\u{f036}",
-        "fa-align-right":"\u{f038}",
-        "fa-ambulance":"\u{f0f9}",
-        "fa-anchor":"\u{f13d}",
-        "fa-android":"\u{f17b}",
-        "fa-angellist":"\u{f209}",
-        "fa-angle-double-down":"\u{f103}",
-        "fa-angle-double-left":"\u{f100}",
-        "fa-angle-double-right":"\u{f101}",
-        "fa-angle-double-up":"\u{f102}",
-        "fa-angle-down":"\u{f107}",
-        "fa-angle-left":"\u{f104}",
-        "fa-angle-right":"\u{f105}",
-        "fa-angle-up":"\u{f106}",
-        "fa-apple":"\u{f179}",
-        "fa-archive":"\u{f187}",
-        "fa-area-chart":"\u{f1fe}",
-        "fa-arrow-circle-down":"\u{f0ab}",
-        "fa-arrow-circle-left":"\u{f0a8}",
-        "fa-arrow-circle-o-down":"\u{f01a}",
-        "fa-arrow-circle-o-left":"\u{f190}",
-        "fa-arrow-circle-o-right":"\u{f18e}",
-        "fa-arrow-circle-o-up":"\u{f01b}",
-        "fa-arrow-circle-right":"\u{f0a9}",
-        "fa-arrow-circle-up":"\u{f0aa}",
-        "fa-arrow-down":"\u{f063}",
-        "fa-arrow-left":"\u{f060}",
-        "fa-arrow-right":"\u{f061}",
-        "fa-arrow-up":"\u{f062}",
-        "fa-arrows":"\u{f047}",
-        "fa-arrows-alt":"\u{f0b2}",
-        "fa-arrows-h":"\u{f07e}",
-        "fa-arrows-v":"\u{f07d}",
-        "fa-asterisk":"\u{f069}",
-        "fa-at":"\u{f1fa}",
-        "fa-automobile (alias)":"\u{f1b9}",
-        "fa-backward":"\u{f04a}",
-        "fa-ban":"\u{f05e}",
-        "fa-bank (alias)":"\u{f19c}",
-        "fa-bar-chart":"\u{f080}",
-        "fa-bar-chart-o (alias)":"\u{f080}",
-        "fa-barcode":"\u{f02a}",
-        "fa-bars":"\u{f0c9}",
-        "fa-bed":"\u{f236}",
-        "fa-beer":"\u{f0fc}",
-        "fa-behance":"\u{f1b4}",
-        "fa-behance-square":"\u{f1b5}",
-        "fa-bell":"\u{f0f3}",
-        "fa-bell-o":"\u{f0a2}",
-        "fa-bell-slash":"\u{f1f6}",
-        "fa-bell-slash-o":"\u{f1f7}",
-        "fa-bicycle":"\u{f206}",
-        "fa-binoculars":"\u{f1e5}",
-        "fa-birthday-cake":"\u{f1fd}",
-        "fa-bitbucket":"\u{f171}",
-        "fa-bitbucket-square":"\u{f172}",
-        "fa-bitcoin (alias)":"\u{f15a}",
-        "fa-bold":"\u{f032}",
-        "fa-bolt":"\u{f0e7}",
-        "fa-bomb":"\u{f1e2}",
-        "fa-book":"\u{f02d}",
-        "fa-bookmark":"\u{f02e}",
-        "fa-bookmark-o":"\u{f097}",
-        "fa-briefcase":"\u{f0b1}",
-        "fa-btc":"\u{f15a}",
-        "fa-bug":"\u{f188}",
-        "fa-building":"\u{f1ad}",
-        "fa-building-o":"\u{f0f7}",
-        "fa-bullhorn":"\u{f0a1}",
-        "fa-bullseye":"\u{f140}",
-        "fa-bus":"\u{f207}",
-        "fa-buysellads":"\u{f20d}",
-        "fa-cab (alias)":"\u{f1ba}",
-        "fa-calculator":"\u{f1ec}",
-        "fa-calendar":"\u{f073}",
-        "fa-calendar-o":"\u{f133}",
-        "fa-camera":"\u{f030}",
-        "fa-camera-retro":"\u{f083}",
-        "fa-car":"\u{f1b9}",
-        "fa-caret-down":"\u{f0d7}",
-        "fa-caret-left":"\u{f0d9}",
-        "fa-caret-right":"\u{f0da}",
-        "fa-caret-square-o-down":"\u{f150}",
-        "fa-caret-square-o-left":"\u{f191}",
-        "fa-caret-square-o-right":"\u{f152}",
-        "fa-caret-square-o-up":"\u{f151}",
-        "fa-caret-up":"\u{f0d8}",
-        "fa-cart-arrow-down":"\u{f218}",
-        "fa-cart-plus":"\u{f217}",
-        "fa-cc":"\u{f20a}",
-        "fa-cc-amex":"\u{f1f3}",
-        "fa-cc-discover":"\u{f1f2}",
-        "fa-cc-mastercard":"\u{f1f1}",
-        "fa-cc-paypal":"\u{f1f4}",
-        "fa-cc-stripe":"\u{f1f5}",
-        "fa-cc-visa":"\u{f1f0}",
-        "fa-certificate":"\u{f0a3}",
-        "fa-chain (alias)":"\u{f0c1}",
-        "fa-chain-broken":"\u{f127}",
-        "fa-check":"\u{f00c}",
-        "fa-check-circle":"\u{f058}",
-        "fa-check-circle-o":"\u{f05d}",
-        "fa-check-square":"\u{f14a}",
-        "fa-check-square-o":"\u{f046}",
-        "fa-chevron-circle-down":"\u{f13a}",
-        "fa-chevron-circle-left":"\u{f137}",
-        "fa-chevron-circle-right":"\u{f138}",
-        "fa-chevron-circle-up":"\u{f139}",
-        "fa-chevron-down":"\u{f078}",
-        "fa-chevron-left":"\u{f053}",
-        "fa-chevron-right":"\u{f054}",
-        "fa-chevron-up":"\u{f077}",
-        "fa-child":"\u{f1ae}",
-        "fa-circle":"\u{f111}",
-        "fa-circle-o":"\u{f10c}",
-        "fa-circle-o-notch":"\u{f1ce}",
-        "fa-circle-thin":"\u{f1db}",
-        "fa-clipboard":"\u{f0ea}",
-        "fa-clock-o":"\u{f017}",
-        "fa-close (alias)":"\u{f00d}",
-        "fa-cloud":"\u{f0c2}",
-        "fa-cloud-download":"\u{f0ed}",
-        "fa-cloud-upload":"\u{f0ee}",
-        "fa-cny (alias)":"\u{f157}",
-        "fa-code":"\u{f121}",
-        "fa-code-fork":"\u{f126}",
-        "fa-codepen":"\u{f1cb}",
-        "fa-coffee":"\u{f0f4}",
-        "fa-cog":"\u{f013}",
-        "fa-cogs":"\u{f085}",
-        "fa-columns":"\u{f0db}",
-        "fa-comment":"\u{f075}",
-        "fa-comment-o":"\u{f0e5}",
-        "fa-comments":"\u{f086}",
-        "fa-comments-o":"\u{f0e6}",
-        "fa-compass":"\u{f14e}",
-        "fa-compress":"\u{f066}",
-        "fa-connectdevelop":"\u{f20e}",
-        "fa-copy (alias)":"\u{f0c5}",
-        "fa-copyright":"\u{f1f9}",
-        "fa-credit-card":"\u{f09d}",
-        "fa-crop":"\u{f125}",
-        "fa-crosshairs":"\u{f05b}",
-        "fa-css3":"\u{f13c}",
-        "fa-cube":"\u{f1b2}",
-        "fa-cubes":"\u{f1b3}",
-        "fa-cut (alias)":"\u{f0c4}",
-        "fa-cutlery":"\u{f0f5}",
-        "fa-dashboard (alias)":"\u{f0e4}",
-        "fa-dashcube":"\u{f210}",
-        "fa-database":"\u{f1c0}",
-        "fa-dedent (alias)":"\u{f03b}",
-        "fa-delicious":"\u{f1a5}",
-        "fa-desktop":"\u{f108}",
-        "fa-deviantart":"\u{f1bd}",
-        "fa-diamond":"\u{f219}",
-        "fa-digg":"\u{f1a6}",
-        "fa-dollar (alias)":"\u{f155}",
-        "fa-dot-circle-o":"\u{f192}",
-        "fa-download":"\u{f019}",
-        "fa-dribbble":"\u{f17d}",
-        "fa-dropbox":"\u{f16b}",
-        "fa-drupal":"\u{f1a9}",
-        "fa-edit (alias)":"\u{f044}",
-        "fa-eject":"\u{f052}",
-        "fa-ellipsis-h":"\u{f141}",
-        "fa-ellipsis-v":"\u{f142}",
-        "fa-empire":"\u{f1d1}",
-        "fa-envelope":"\u{f0e0}",
-        "fa-envelope-o":"\u{f003}",
-        "fa-envelope-square":"\u{f199}",
-        "fa-eraser":"\u{f12d}",
-        "fa-eur":"\u{f153}",
-        "fa-euro (alias)":"\u{f153}",
-        "fa-exchange":"\u{f0ec}",
-        "fa-exclamation":"\u{f12a}",
-        "fa-exclamation-circle":"\u{f06a}",
-        "fa-exclamation-triangle":"\u{f071}",
-        "fa-expand":"\u{f065}",
-        "fa-external-link":"\u{f08e}",
-        "fa-external-link-square":"\u{f14c}",
-        "fa-eye":"\u{f06e}",
-        "fa-eye-slash":"\u{f070}",
-        "fa-eyedropper":"\u{f1fb}",
-        "fa-facebook":"\u{f09a}",
-        "fa-facebook-f (alias)":"\u{f09a}",
-        "fa-facebook-official":"\u{f230}",
-        "fa-facebook-square":"\u{f082}",
-        "fa-fast-backward":"\u{f049}",
-        "fa-fast-forward":"\u{f050}",
-        "fa-fax":"\u{f1ac}",
-        "fa-female":"\u{f182}",
-        "fa-fighter-jet":"\u{f0fb}",
-        "fa-file":"\u{f15b}",
-        "fa-file-archive-o":"\u{f1c6}",
-        "fa-file-audio-o":"\u{f1c7}",
-        "fa-file-code-o":"\u{f1c9}",
-        "fa-file-excel-o":"\u{f1c3}",
-        "fa-file-image-o":"\u{f1c5}",
-        "fa-file-movie-o (alias)":"\u{f1c8}",
-        "fa-file-o":"\u{f016}",
-        "fa-file-pdf-o":"\u{f1c1}",
-        "fa-file-photo-o (alias)":"\u{f1c5}",
-        "fa-file-picture-o (alias)":"\u{f1c5}",
-        "fa-file-powerpoint-o":"\u{f1c4}",
-        "fa-file-sound-o (alias)":"\u{f1c7}",
-        "fa-file-text":"\u{f15c}",
-        "fa-file-text-o":"\u{f0f6}",
-        "fa-file-video-o":"\u{f1c8}",
-        "fa-file-word-o":"\u{f1c2}",
-        "fa-file-zip-o (alias)":"\u{f1c6}",
-        "fa-files-o":"\u{f0c5}",
-        "fa-film":"\u{f008}",
-        "fa-filter":"\u{f0b0}",
-        "fa-fire":"\u{f06d}",
-        "fa-fire-extinguisher":"\u{f134}",
-        "fa-flag":"\u{f024}",
-        "fa-flag-checkered":"\u{f11e}",
-        "fa-flag-o":"\u{f11d}",
-        "fa-flash (alias)":"\u{f0e7}",
-        "fa-flask":"\u{f0c3}",
-        "fa-flickr":"\u{f16e}",
-        "fa-floppy-o":"\u{f0c7}",
-        "fa-folder":"\u{f07b}",
-        "fa-folder-o":"\u{f114}",
-        "fa-folder-open":"\u{f07c}",
-        "fa-folder-open-o":"\u{f115}",
-        "fa-font":"\u{f031}",
-        "fa-forumbee":"\u{f211}",
-        "fa-forward":"\u{f04e}",
-        "fa-foursquare":"\u{f180}",
-        "fa-frown-o":"\u{f119}",
-        "fa-futbol-o":"\u{f1e3}",
-        "fa-gamepad":"\u{f11b}",
-        "fa-gavel":"\u{f0e3}",
-        "fa-gbp":"\u{f154}",
-        "fa-ge (alias)":"\u{f1d1}",
-        "fa-gear (alias)":"\u{f013}",
-        "fa-gears (alias)":"\u{f085}",
-        "fa-genderless (alias)":"\u{f1db}",
-        "fa-gift":"\u{f06b}",
-        "fa-git":"\u{f1d3}",
-        "fa-git-square":"\u{f1d2}",
-        "fa-github":"\u{f09b}",
-        "fa-github-alt":"\u{f113}",
-        "fa-github-square":"\u{f092}",
-        "fa-gittip (alias)":"\u{f184}",
-        "fa-glass":"\u{f000}",
-        "fa-globe":"\u{f0ac}",
-        "fa-google":"\u{f1a0}",
-        "fa-google-plus":"\u{f0d5}",
-        "fa-google-plus-square":"\u{f0d4}",
-        "fa-google-wallet":"\u{f1ee}",
-        "fa-graduation-cap":"\u{f19d}",
-        "fa-gratipay":"\u{f184}",
-        "fa-group (alias)":"\u{f0c0}",
-        "fa-h-square":"\u{f0fd}",
-        "fa-hacker-news":"\u{f1d4}",
-        "fa-hand-o-down":"\u{f0a7}",
-        "fa-hand-o-left":"\u{f0a5}",
-        "fa-hand-o-right":"\u{f0a4}",
-        "fa-hand-o-up":"\u{f0a6}",
-        "fa-hdd-o":"\u{f0a0}",
-        "fa-header":"\u{f1dc}",
-        "fa-headphones":"\u{f025}",
-        "fa-heart":"\u{f004}",
-        "fa-heart-o":"\u{f08a}",
-        "fa-heartbeat":"\u{f21e}",
-        "fa-history":"\u{f1da}",
-        "fa-home":"\u{f015}",
-        "fa-hospital-o":"\u{f0f8}",
-        "fa-hotel (alias)":"\u{f236}",
-        "fa-html5":"\u{f13b}",
-        "fa-ils":"\u{f20b}",
-        "fa-image (alias)":"\u{f03e}",
-        "fa-inbox":"\u{f01c}",
-        "fa-indent":"\u{f03c}",
-        "fa-info":"\u{f129}",
-        "fa-info-circle":"\u{f05a}",
-        "fa-inr":"\u{f156}",
-        "fa-instagram":"\u{f16d}",
-        "fa-institution (alias)":"\u{f19c}",
-        "fa-ioxhost":"\u{f208}",
-        "fa-italic":"\u{f033}",
-        "fa-joomla":"\u{f1aa}",
-        "fa-jpy":"\u{f157}",
-        "fa-jsfiddle":"\u{f1cc}",
-        "fa-key":"\u{f084}",
-        "fa-keyboard-o":"\u{f11c}",
-        "fa-krw":"\u{f159}",
-        "fa-language":"\u{f1ab}",
-        "fa-laptop":"\u{f109}",
-        "fa-lastfm":"\u{f202}",
-        "fa-lastfm-square":"\u{f203}",
-        "fa-leaf":"\u{f06c}",
-        "fa-leanpub":"\u{f212}",
-        "fa-legal (alias)":"\u{f0e3}",
-        "fa-lemon-o":"\u{f094}",
-        "fa-level-down":"\u{f149}",
-        "fa-level-up":"\u{f148}",
-        "fa-life-bouy (alias)":"\u{f1cd}",
-        "fa-life-buoy (alias)":"\u{f1cd}",
-        "fa-life-ring":"\u{f1cd}",
-        "fa-life-saver (alias)":"\u{f1cd}",
-        "fa-lightbulb-o":"\u{f0eb}",
-        "fa-line-chart":"\u{f201}",
-        "fa-link":"\u{f0c1}",
-        "fa-linkedin":"\u{f0e1}",
-        "fa-linkedin-square":"\u{f08c}",
-        "fa-linux":"\u{f17c}",
-        "fa-list":"\u{f03a}",
-        "fa-list-alt":"\u{f022}",
-        "fa-list-ol":"\u{f0cb}",
-        "fa-list-ul":"\u{f0ca}",
-        "fa-location-arrow":"\u{f124}",
-        "fa-lock":"\u{f023}",
-        "fa-long-arrow-down":"\u{f175}",
-        "fa-long-arrow-left":"\u{f177}",
-        "fa-long-arrow-right":"\u{f178}",
-        "fa-long-arrow-up":"\u{f176}",
-        "fa-magic":"\u{f0d0}",
-        "fa-magnet":"\u{f076}",
-        "fa-mail-forward (alias)":"\u{f064}",
-        "fa-mail-reply (alias)":"\u{f112}",
-        "fa-mail-reply-all (alias)":"\u{f122}",
-        "fa-male":"\u{f183}",
-        "fa-map-marker":"\u{f041}",
-        "fa-mars":"\u{f222}",
-        "fa-mars-double":"\u{f227}",
-        "fa-mars-stroke":"\u{f229}",
-        "fa-mars-stroke-h":"\u{f22b}",
-        "fa-mars-stroke-v":"\u{f22a}",
-        "fa-maxcdn":"\u{f136}",
-        "fa-meanpath":"\u{f20c}",
-        "fa-medium":"\u{f23a}",
-        "fa-medkit":"\u{f0fa}",
-        "fa-meh-o":"\u{f11a}",
-        "fa-mercury":"\u{f223}",
-        "fa-microphone":"\u{f130}",
-        "fa-microphone-slash":"\u{f131}",
-        "fa-minus":"\u{f068}",
-        "fa-minus-circle":"\u{f056}",
-        "fa-minus-square":"\u{f146}",
-        "fa-minus-square-o":"\u{f147}",
-        "fa-mobile":"\u{f10b}",
-        "fa-mobile-phone (alias)":"\u{f10b}",
-        "fa-money":"\u{f0d6}",
-        "fa-moon-o":"\u{f186}",
-        "fa-mortar-board (alias)":"\u{f19d}",
-        "fa-motorcycle":"\u{f21c}",
-        "fa-music":"\u{f001}",
-        "fa-navicon (alias)":"\u{f0c9}",
-        "fa-neuter":"\u{f22c}",
-        "fa-newspaper-o":"\u{f1ea}",
-        "fa-openid":"\u{f19b}",
-        "fa-outdent":"\u{f03b}",
-        "fa-pagelines":"\u{f18c}",
-        "fa-paint-brush":"\u{f1fc}",
-        "fa-paper-plane":"\u{f1d8}",
-        "fa-paper-plane-o":"\u{f1d9}",
-        "fa-paperclip":"\u{f0c6}",
-        "fa-paragraph":"\u{f1dd}",
-        "fa-paste (alias)":"\u{f0ea}",
-        "fa-pause":"\u{f04c}",
-        "fa-paw":"\u{f1b0}",
-        "fa-paypal":"\u{f1ed}",
-        "fa-pencil":"\u{f040}",
-        "fa-pencil-square":"\u{f14b}",
-        "fa-pencil-square-o":"\u{f044}",
-        "fa-phone":"\u{f095}",
-        "fa-phone-square":"\u{f098}",
-        "fa-photo (alias)":"\u{f03e}",
-        "fa-picture-o":"\u{f03e}",
-        "fa-pie-chart":"\u{f200}",
-        "fa-pied-piper":"\u{f1a7}",
-        "fa-pied-piper-alt":"\u{f1a8}",
-        "fa-pinterest":"\u{f0d2}",
-        "fa-pinterest-p":"\u{f231}",
-        "fa-pinterest-square":"\u{f0d3}",
-        "fa-plane":"\u{f072}",
-        "fa-play":"\u{f04b}",
-        "fa-play-circle":"\u{f144}",
-        "fa-play-circle-o":"\u{f01d}",
-        "fa-plug":"\u{f1e6}",
-        "fa-plus":"\u{f067}",
-        "fa-plus-circle":"\u{f055}",
-        "fa-plus-square":"\u{f0fe}",
-        "fa-plus-square-o":"\u{f196}",
-        "fa-power-off":"\u{f011}",
-        "fa-print":"\u{f02f}",
-        "fa-puzzle-piece":"\u{f12e}",
-        "fa-qq":"\u{f1d6}",
-        "fa-qrcode":"\u{f029}",
-        "fa-question":"\u{f128}",
-        "fa-question-circle":"\u{f059}",
-        "fa-quote-left":"\u{f10d}",
-        "fa-quote-right":"\u{f10e}",
-        "fa-ra (alias)":"\u{f1d0}",
-        "fa-random":"\u{f074}",
-        "fa-rebel":"\u{f1d0}",
-        "fa-recycle":"\u{f1b8}",
-        "fa-reddit":"\u{f1a1}",
-        "fa-reddit-square":"\u{f1a2}",
-        "fa-refresh":"\u{f021}",
-        "fa-remove (alias)":"\u{f00d}",
-        "fa-renren":"\u{f18b}",
-        "fa-reorder (alias)":"\u{f0c9}",
-        "fa-repeat":"\u{f01e}",
-        "fa-reply":"\u{f112}",
-        "fa-reply-all":"\u{f122}",
-        "fa-retweet":"\u{f079}",
-        "fa-rmb (alias)":"\u{f157}",
-        "fa-road":"\u{f018}",
-        "fa-rocket":"\u{f135}",
-        "fa-rotate-left (alias)":"\u{f0e2}",
-        "fa-rotate-right (alias)":"\u{f01e}",
-        "fa-rouble (alias)":"\u{f158}",
-        "fa-rss":"\u{f09e}",
-        "fa-rss-square":"\u{f143}",
-        "fa-rub":"\u{f158}",
-        "fa-ruble (alias)":"\u{f158}",
-        "fa-rupee (alias)":"\u{f156}",
-        "fa-save (alias)":"\u{f0c7}",
-        "fa-scissors":"\u{f0c4}",
-        "fa-search":"\u{f002}",
-        "fa-search-minus":"\u{f010}",
-        "fa-search-plus":"\u{f00e}",
-        "fa-sellsy":"\u{f213}",
-        "fa-send (alias)":"\u{f1d8}",
-        "fa-send-o (alias)":"\u{f1d9}",
-        "fa-server":"\u{f233}",
-        "fa-share":"\u{f064}",
-        "fa-share-alt":"\u{f1e0}",
-        "fa-share-alt-square":"\u{f1e1}",
-        "fa-share-square":"\u{f14d}",
-        "fa-share-square-o":"\u{f045}",
-        "fa-shekel (alias)":"\u{f20b}",
-        "fa-sheqel (alias)":"\u{f20b}",
-        "fa-shield":"\u{f132}",
-        "fa-ship":"\u{f21a}",
-        "fa-shirtsinbulk":"\u{f214}",
-        "fa-shopping-cart":"\u{f07a}",
-        "fa-sign-in":"\u{f090}",
-        "fa-sign-out":"\u{f08b}",
-        "fa-signal":"\u{f012}",
-        "fa-simplybuilt":"\u{f215}",
-        "fa-sitemap":"\u{f0e8}",
-        "fa-skyatlas":"\u{f216}",
-        "fa-skype":"\u{f17e}",
-        "fa-slack":"\u{f198}",
-        "fa-sliders":"\u{f1de}",
-        "fa-slideshare":"\u{f1e7}",
-        "fa-smile-o":"\u{f118}",
-        "fa-soccer-ball-o (alias)":"\u{f1e3}",
-        "fa-sort":"\u{f0dc}",
-        "fa-sort-alpha-asc":"\u{f15d}",
-        "fa-sort-alpha-desc":"\u{f15e}",
-        "fa-sort-amount-asc":"\u{f160}",
-        "fa-sort-amount-desc":"\u{f161}",
-        "fa-sort-asc":"\u{f0de}",
-        "fa-sort-desc":"\u{f0dd}",
-        "fa-sort-down (alias)":"\u{f0dd}",
-        "fa-sort-numeric-asc":"\u{f162}",
-        "fa-sort-numeric-desc":"\u{f163}",
-        "fa-sort-up (alias)":"\u{f0de}",
-        "fa-soundcloud":"\u{f1be}",
-        "fa-space-shuttle":"\u{f197}",
-        "fa-spinner":"\u{f110}",
-        "fa-spoon":"\u{f1b1}",
-        "fa-spotify":"\u{f1bc}",
-        "fa-square":"\u{f0c8}",
-        "fa-square-o":"\u{f096}",
-        "fa-stack-exchange":"\u{f18d}",
-        "fa-stack-overflow":"\u{f16c}",
-        "fa-star":"\u{f005}",
-        "fa-star-half":"\u{f089}",
-        "fa-star-half-empty (alias)":"\u{f123}",
-        "fa-star-half-full (alias)":"\u{f123}",
-        "fa-star-half-o":"\u{f123}",
-        "fa-star-o":"\u{f006}",
-        "fa-steam":"\u{f1b6}",
-        "fa-steam-square":"\u{f1b7}",
-        "fa-step-backward":"\u{f048}",
-        "fa-step-forward":"\u{f051}",
-        "fa-stethoscope":"\u{f0f1}",
-        "fa-stop":"\u{f04d}",
-        "fa-street-view":"\u{f21d}",
-        "fa-strikethrough":"\u{f0cc}",
-        "fa-stumbleupon":"\u{f1a4}",
-        "fa-stumbleupon-circle":"\u{f1a3}",
-        "fa-subscript":"\u{f12c}",
-        "fa-subway":"\u{f239}",
-        "fa-suitcase":"\u{f0f2}",
-        "fa-sun-o":"\u{f185}",
-        "fa-superscript":"\u{f12b}",
-        "fa-support (alias)":"\u{f1cd}",
-        "fa-table":"\u{f0ce}",
-        "fa-tablet":"\u{f10a}",
-        "fa-tachometer":"\u{f0e4}",
-        "fa-tag":"\u{f02b}",
-        "fa-tags":"\u{f02c}",
-        "fa-tasks":"\u{f0ae}",
-        "fa-taxi":"\u{f1ba}",
-        "fa-tencent-weibo":"\u{f1d5}",
-        "fa-terminal":"\u{f120}",
-        "fa-text-height":"\u{f034}",
-        "fa-text-width":"\u{f035}",
-        "fa-th":"\u{f00a}",
-        "fa-th-large":"\u{f009}",
-        "fa-th-list":"\u{f00b}",
-        "fa-thumb-tack":"\u{f08d}",
-        "fa-thumbs-down":"\u{f165}",
-        "fa-thumbs-o-down":"\u{f088}",
-        "fa-thumbs-o-up":"\u{f087}",
-        "fa-thumbs-up":"\u{f164}",
-        "fa-ticket":"\u{f145}",
-        "fa-times":"\u{f00d}",
-        "fa-times-circle":"\u{f057}",
-        "fa-times-circle-o":"\u{f05c}",
-        "fa-tint":"\u{f043}",
-        "fa-toggle-down (alias)":"\u{f150}",
-        "fa-toggle-left (alias)":"\u{f191}",
-        "fa-toggle-off":"\u{f204}",
-        "fa-toggle-on":"\u{f205}",
-        "fa-toggle-right (alias)":"\u{f152}",
-        "fa-toggle-up (alias)":"\u{f151}",
-        "fa-train":"\u{f238}",
-        "fa-transgender":"\u{f224}",
-        "fa-transgender-alt":"\u{f225}",
-        "fa-trash":"\u{f1f8}",
-        "fa-trash-o":"\u{f014}",
-        "fa-tree":"\u{f1bb}",
-        "fa-trello":"\u{f181}",
-        "fa-trophy":"\u{f091}",
-        "fa-truck":"\u{f0d1}",
-        "fa-try":"\u{f195}",
-        "fa-tty":"\u{f1e4}",
-        "fa-tumblr":"\u{f173}",
-        "fa-tumblr-square":"\u{f174}",
-        "fa-turkish-lira (alias)":"\u{f195}",
-        "fa-twitch":"\u{f1e8}",
-        "fa-twitter":"\u{f099}",
-        "fa-twitter-square":"\u{f081}",
-        "fa-umbrella":"\u{f0e9}",
-        "fa-underline":"\u{f0cd}",
-        "fa-undo":"\u{f0e2}",
-        "fa-university":"\u{f19c}",
-        "fa-unlink (alias)":"\u{f127}",
-        "fa-unlock":"\u{f09c}",
-        "fa-unlock-alt":"\u{f13e}",
-        "fa-unsorted (alias)":"\u{f0dc}",
-        "fa-upload":"\u{f093}",
-        "fa-usd":"\u{f155}",
-        "fa-user":"\u{f007}",
-        "fa-user-md":"\u{f0f0}",
-        "fa-user-plus":"\u{f234}",
-        "fa-user-secret":"\u{f21b}",
-        "fa-user-times":"\u{f235}",
-        "fa-users":"\u{f0c0}",
-        "fa-venus":"\u{f221}",
-        "fa-venus-double":"\u{f226}",
-        "fa-venus-mars":"\u{f228}",
-        "fa-viacoin":"\u{f237}",
-        "fa-video-camera":"\u{f03d}",
-        "fa-vimeo-square":"\u{f194}",
-        "fa-vine":"\u{f1ca}",
-        "fa-vk":"\u{f189}",
-        "fa-volume-down":"\u{f027}",
-        "fa-volume-off":"\u{f026}",
-        "fa-volume-up":"\u{f028}",
-        "fa-warning (alias)":"\u{f071}",
-        "fa-wechat (alias)":"\u{f1d7}",
-        "fa-weibo":"\u{f18a}",
-        "fa-weixin":"\u{f1d7}",
-        "fa-whatsapp":"\u{f232}",
-        "fa-wheelchair":"\u{f193}",
-        "fa-wifi":"\u{f1eb}",
-        "fa-windows":"\u{f17a}",
-        "fa-won (alias)":"\u{f159}",
-        "fa-wordpress":"\u{f19a}",
-        "fa-wrench":"\u{f0ad}",
-        "fa-xing":"\u{f168}",
-        "fa-xing-square":"\u{f169}",
-        "fa-yahoo":"\u{f19e}",
-        "fa-yelp":"\u{f1e9}",
-        "fa-yen (alias)":"\u{f157}",
-        "fa-youtube":"\u{f167}",
-        "fa-youtube-play":"\u{f16a}"
-      ]
+    public static func fontAwesomeIconWithName(name: FontAwesome) -> String {
+        var icons: [String: String]?
+        var token: dispatch_once_t = 0
+        
+        return name.rawValue.substringToIndex(advance(name.rawValue.startIndex, 1))
     }
-
-    if icons!.indexForKey(name) == nil {
-      println("FontAwesome.swift: icon \"\(name)\" not available")
-      return icons!["fa-times-circle-o"]!
-    }
-
-    return icons![name]!
-  }
 }

--- a/Demo/FontAwesome.swift/ViewController.swift
+++ b/Demo/FontAwesome.swift/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: UIViewController {
     super.viewDidLoad()
     
     label.font = UIFont.fontAwesomeOfSize(200)
-    label.text = String.fontAwesomeIconWithName("fa-github")
+    label.text = String.fontAwesomeIconWithName(FontAwesome.Github)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Use Font Awesome in your Swift projects
 ```swift
 var myLabel: UILabel!
 myLabel.font = UIFont.fontAwesomeOfSize(200)
-myLabel.text = String.fontAwesomeIconWithName("fa-github")
+myLabel.text = String.fontAwesomeIconWithName(FontAwesome.Github)
 
 ```
 


### PR DESCRIPTION
This adds auto-complete in Xcode and also prevent use of invalid icons.

Since Swift enums must have unique raw values, aliases are handled by appending A after the raw value. If there are multiple aliases, they are numbered B, C, D, etc... until duplicates are removed. This extra value is stripped off (although perhaps this could be more efficient)