### PR TITLE
Fix for compilation error on swift 2.0 Xcode 7

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -69,7 +69,7 @@ public extension UIFont {
 
 public extension String {
     public static func fontAwesomeIconWithName(name: FontAwesome) -> String {
-        return name.rawValue.substringToIndex(advance(name.rawValue.startIndex, 1))
+        return name.rawValue.substringToIndex(name.rawValue.startIndex.advancedBy(1))
     }
 }
 


### PR DESCRIPTION
It was throwing this error when compiled on latest Xcode:

'advance' is unavailable: call the 'advancedBy(n)' method on the index