### PR TITLE
Fixed icons being clipped when creating image.

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -79,9 +79,9 @@ public extension UIImage {
         paragraph.alignment = NSTextAlignment.Center
         
         // Taken from FontAwesome.io's Fixed Width Icon CSS
-        let magicNumber: CGFloat = 1.28571429
+        let fontAspectRatio: CGFloat = 1.28571429
         
-        let fontSize = min(size.width / magicNumber, size.height)
+        let fontSize = min(size.width / fontAspectRatio, size.height)
         let attributedString = NSAttributedString(string: String.fontAwesomeIconWithName(name) as String, attributes: [NSFontAttributeName: UIFont.fontAwesomeOfSize(fontSize), NSForegroundColorAttributeName: textColor, NSParagraphStyleAttributeName: paragraph])
         UIGraphicsBeginImageContextWithOptions(size, false , 0.0)
         attributedString.drawInRect(CGRectMake(0, (size.height - fontSize) / 2, size.width, fontSize))

--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -76,21 +76,18 @@ public extension String {
 public extension UIImage {
     public static func fontAwesomeIconWithName(name: FontAwesome, textColor: UIColor, size: CGSize) -> UIImage {
         let paragraph = NSMutableParagraphStyle()
-        paragraph.lineBreakMode = NSLineBreakMode.ByWordWrapping
-        paragraph.alignment = .Center
-        let attributedString = NSAttributedString(string: String.fontAwesomeIconWithName(name) as String, attributes: [NSFontAttributeName: UIFont.fontAwesomeOfSize(max(size.width, size.height)), NSForegroundColorAttributeName: textColor, NSParagraphStyleAttributeName:paragraph])
-        let size = attributedString.sizeWithMaxWidth(size.width)
+        paragraph.alignment = NSTextAlignment.Center
+        
+        // Taken from FontAwesome.io's Fixed Width Icon CSS
+        let magicNumber: CGFloat = 1.28571429
+        
+        let fontSize = min(size.width / magicNumber, size.height)
+        let attributedString = NSAttributedString(string: String.fontAwesomeIconWithName(name) as String, attributes: [NSFontAttributeName: UIFont.fontAwesomeOfSize(fontSize), NSForegroundColorAttributeName: textColor, NSParagraphStyleAttributeName: paragraph])
         UIGraphicsBeginImageContextWithOptions(size, false , 0.0)
-        attributedString.drawInRect(CGRectMake(0, 0, size.width, size.height))
+        attributedString.drawInRect(CGRectMake(0, (size.height - fontSize) / 2, size.width, fontSize))
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         return image
-    }
-}
-
-private extension NSAttributedString {
-    func sizeWithMaxWidth(maxWidth: CGFloat) -> CGSize {
-        return self.boundingRectWithSize(CGSizeMake(maxWidth, 1000), options:(NSStringDrawingOptions.UsesLineFragmentOrigin), context: nil).size
     }
 }
 


### PR DESCRIPTION
Fixes issue #46 

* Word Wrapping not required because it is a single icon being drawn.
* `sizeWithMaxWidth` returns the same value as the font size, so it's not needed.
* `magicNumber` taken from FontAwesome.io's Fixed Width Icon CSS, which I believe is the aspect ratio of the widest icon (or wider than).
* Icons will not be the exact size provided, but different icons given the same image size will be of the same font size.
* Adds vertical alignment that was previously missing.