### PR TITLE
Ability to get FontAwesome enum name from CSS code

### DIFF
--- a/FontAwesome/Enum.swift
+++ b/FontAwesome/Enum.swift
@@ -716,6 +716,18 @@ public enum FontAwesome: String {
     case Bluetooth = "\u{f293}"
     case BluetoothB = "\u{f294}"
     case Percent = "\u{f295}"
+    
+    /// Get a FontAwesome string from the given CSS icon code. Icon code can be found here: http://fontawesome.io/icons/
+    ///
+    /// - parameter code: The preferred icon name.
+    /// - returns: FontAwesome icon.
+    public static func fromCode(code: String) -> FontAwesome? {
+        guard let raw = FontAwesomeIcons[code], icon = FontAwesome(rawValue: raw) else {
+            return nil
+        }
+        
+        return icon
+    }
 }
 
 /// An array of FontAwesome icon codes.


### PR DESCRIPTION
As example usage, for making UIImage, knowing only CSS name:

```swift
let code = product.icon ?? "cube"
let faIcon = FontAwesome.fromCode("fa-\(code)") ?? .Cube
        
cell.imageView?.image = UIImage.fontAwesomeIconWithName(faIcon, textColor: color, size: size)
```