### PR TITLE
Wait to force unwrap the fontURL to resolve crash.

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -129,7 +129,7 @@ private class FontLoader {
 
         if identifier?.hasPrefix("org.cocoapods") == true {
             // If this framework is added using CocoaPods, resources is placed under a subdirectory
-            fontURL = bundle.url(forResource: name, withExtension: "otf", subdirectory: "FontAwesome.swift.bundle")!
+            fontURL = bundle.url(forResource: name, withExtension: "otf", subdirectory: "FontAwesome.swift.bundle")
         }
 
         let data = try! Data(contentsOf: fontURL!)


### PR DESCRIPTION
When using cocoapods this fontURL is initially `nil`, force unwrapping it here causes a crash. Instead, wait until after the cocoapods specific check to unwrap.