### PR TITLE
Added FontAwesomeViews for storyboard

### DIFF
--- a/FontAwesome.xcodeproj/project.pbxproj
+++ b/FontAwesome.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		484F4A3D1ECC816A0010B0BA /* FontAwesomeBarButtonItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A361ECC816A0010B0BA /* FontAwesomeBarButtonItem.swift */; };
+		484F4A3E1ECC816A0010B0BA /* FontAwesomeImageRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A371ECC816A0010B0BA /* FontAwesomeImageRepresentable.swift */; };
+		484F4A3F1ECC816A0010B0BA /* FontAwesomeImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A381ECC816A0010B0BA /* FontAwesomeImageView.swift */; };
+		484F4A401ECC816A0010B0BA /* FontAwesomeSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A391ECC816A0010B0BA /* FontAwesomeSegmentedControl.swift */; };
+		484F4A411ECC816A0010B0BA /* FontAwesomeStateRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A3A1ECC816A0010B0BA /* FontAwesomeStateRequirement.swift */; };
+		484F4A421ECC816A0010B0BA /* FontAwesomeTabBarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A3B1ECC816A0010B0BA /* FontAwesomeTabBarItem.swift */; };
+		484F4A431ECC816A0010B0BA /* FontAwesomeTextRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 484F4A3C1ECC816A0010B0BA /* FontAwesomeTextRepresentable.swift */; };
 		4D8AFBEE1E9459210046C7F6 /* FontAwesome.h in Headers */ = {isa = PBXBuildFile; fileRef = 8401A8D71B39601400269D14 /* FontAwesome.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4DF4FB961E94582700F03B22 /* FontAwesome.otf in Resources */ = {isa = PBXBuildFile; fileRef = 8401A8F21B3961B800269D14 /* FontAwesome.otf */; };
 		4DF4FB971E94582B00F03B22 /* FontAwesome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8401A8F01B39610F00269D14 /* FontAwesome.swift */; };
@@ -36,6 +43,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		484F4A361ECC816A0010B0BA /* FontAwesomeBarButtonItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeBarButtonItem.swift; sourceTree = "<group>"; };
+		484F4A371ECC816A0010B0BA /* FontAwesomeImageRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeImageRepresentable.swift; sourceTree = "<group>"; };
+		484F4A381ECC816A0010B0BA /* FontAwesomeImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeImageView.swift; sourceTree = "<group>"; };
+		484F4A391ECC816A0010B0BA /* FontAwesomeSegmentedControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeSegmentedControl.swift; sourceTree = "<group>"; };
+		484F4A3A1ECC816A0010B0BA /* FontAwesomeStateRequirement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeStateRequirement.swift; sourceTree = "<group>"; };
+		484F4A3B1ECC816A0010B0BA /* FontAwesomeTabBarItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeTabBarItem.swift; sourceTree = "<group>"; };
+		484F4A3C1ECC816A0010B0BA /* FontAwesomeTextRepresentable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FontAwesomeTextRepresentable.swift; sourceTree = "<group>"; };
 		4DF4FB8E1E94581300F03B22 /* FontAwesome.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FontAwesome.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8401A8D21B39601400269D14 /* FontAwesome.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FontAwesome.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8401A8D61B39601400269D14 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -106,6 +120,13 @@
 		8401A8D41B39601400269D14 /* FontAwesome */ = {
 			isa = PBXGroup;
 			children = (
+				484F4A361ECC816A0010B0BA /* FontAwesomeBarButtonItem.swift */,
+				484F4A371ECC816A0010B0BA /* FontAwesomeImageRepresentable.swift */,
+				484F4A381ECC816A0010B0BA /* FontAwesomeImageView.swift */,
+				484F4A391ECC816A0010B0BA /* FontAwesomeSegmentedControl.swift */,
+				484F4A3A1ECC816A0010B0BA /* FontAwesomeStateRequirement.swift */,
+				484F4A3B1ECC816A0010B0BA /* FontAwesomeTabBarItem.swift */,
+				484F4A3C1ECC816A0010B0BA /* FontAwesomeTextRepresentable.swift */,
 				8401A8D71B39601400269D14 /* FontAwesome.h */,
 				8401A8F01B39610F00269D14 /* FontAwesome.swift */,
 				84DBFFAC1D8A7E76002C4517 /* FontAwesomeView.swift */,
@@ -340,6 +361,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				841575DA1B3A490A001092B6 /* Enum.swift in Sources */,
+				484F4A3E1ECC816A0010B0BA /* FontAwesomeImageRepresentable.swift in Sources */,
+				484F4A411ECC816A0010B0BA /* FontAwesomeStateRequirement.swift in Sources */,
+				484F4A421ECC816A0010B0BA /* FontAwesomeTabBarItem.swift in Sources */,
+				484F4A431ECC816A0010B0BA /* FontAwesomeTextRepresentable.swift in Sources */,
+				484F4A3D1ECC816A0010B0BA /* FontAwesomeBarButtonItem.swift in Sources */,
+				484F4A401ECC816A0010B0BA /* FontAwesomeSegmentedControl.swift in Sources */,
+				484F4A3F1ECC816A0010B0BA /* FontAwesomeImageView.swift in Sources */,
 				8401A8F11B39610F00269D14 /* FontAwesome.swift in Sources */,
 				84DBFFAD1D8A7E76002C4517 /* FontAwesomeView.swift in Sources */,
 			);

--- a/FontAwesome/FontAwesomeBarButtonItem.swift
+++ b/FontAwesome/FontAwesomeBarButtonItem.swift
@@ -1,0 +1,68 @@
+// FontAwesomeBarButtonItem.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+@IBDesignable public class FontAwesomeBarButtonItem: UIBarButtonItem {
+    
+    @IBInspectable public var isFontAwesomeCSSCode: Bool = true
+    @IBInspectable public var size: CGFloat = 25.0
+    
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+        useFontAwesome()
+    }
+    
+    public override func prepareForInterfaceBuilder() {
+        useFontAwesome()
+    }
+    
+    private func useFontAwesome() {
+        updateText {
+            if let cssCode = title {
+                title = String.fontAwesomeIcon(code: cssCode)
+            }
+        }
+        updateFontAttributes { (state, font) in
+            var attributes = titleTextAttributes(for: state) ?? [:]
+            attributes[NSFontAttributeName] = font
+            setTitleTextAttributes(attributes, for: state)
+        }
+    }
+    
+}
+
+extension FontAwesomeBarButtonItem: FontAwesomeTextRepresentable {
+    
+    var isTextCSSCode: Bool {
+        return isFontAwesomeCSSCode
+    }
+    
+    var textSize: CGFloat {
+        return size
+    }
+    
+    static func supportedStates() -> [UIControlState] {
+        return [.normal, .highlighted, .disabled]
+    }
+    
+}

--- a/FontAwesome/FontAwesomeImageRepresentable.swift
+++ b/FontAwesome/FontAwesomeImageRepresentable.swift
@@ -1,0 +1,56 @@
+// FontAwesomeImageRepresentable.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+protocol FontAwesomeImageRepresentable: class {
+    
+    typealias ImageConfig = (cssIconName: String, color: UIColor?, backgroundColor: UIColor?)
+    
+    var imageWidth: CGFloat { get }
+    var imageConfigs: [ImageConfig] { get }
+    
+    func createImages(configurationHandler: (_ image: UIImage?, _ index: Int) -> ())
+}
+
+extension FontAwesomeImageRepresentable {
+    
+    func createImages(configurationHandler: (_ image: UIImage?, _ index: Int) -> ()) {
+        let imgSize = imageSizeForAspectRatio()
+        for (index, config) in imageConfigs.enumerated() {
+            let img = createImage(config: config, size: imgSize)
+            configurationHandler(img, index)
+        }
+    }
+    
+    private func createImage(config: ImageConfig, size: CGSize) -> UIImage? {
+        return UIImage.fontAwesomeIcon(code: config.cssIconName,
+                                       textColor: config.color ?? .black,
+                                       size: size,
+                                       backgroundColor: config.backgroundColor ?? .clear)
+    }
+    
+    private func imageSizeForAspectRatio() -> CGSize {
+        let fontAspectRatio: CGFloat = 1.28571429
+        return CGSize(width: imageWidth, height: imageWidth / fontAspectRatio)
+    }
+}

--- a/FontAwesome/FontAwesomeImageView.swift
+++ b/FontAwesome/FontAwesomeImageView.swift
@@ -1,0 +1,58 @@
+// FontAwesomeImageView.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+@IBDesignable class FontAwesomeImageView: UIImageView {
+    
+    @IBInspectable var cssCode: String = "fa-square-o"
+    @IBInspectable var imageColor: UIColor = .black
+    @IBInspectable var imageBackgroundColor: UIColor = .clear
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        useFontAwesomeImage()
+    }
+    
+    override func prepareForInterfaceBuilder() {
+        useFontAwesomeImage()
+    }
+    
+    private func useFontAwesomeImage() {
+        createImages { (img, _) in
+            image = img
+        }
+    }
+    
+}
+
+extension FontAwesomeImageView: FontAwesomeImageRepresentable {
+    
+    var imageWidth: CGFloat {
+        return frame.width
+    }
+    
+    var imageConfigs: [ImageConfig] {
+        return [(cssCode, imageColor, imageBackgroundColor)]
+    }
+    
+}

--- a/FontAwesome/FontAwesomeSegmentedControl.swift
+++ b/FontAwesome/FontAwesomeSegmentedControl.swift
@@ -1,0 +1,74 @@
+// FontAwesomeSegmentedControl.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+@IBDesignable public class FontAwesomeSegmentedControl: UISegmentedControl {
+    
+    @IBInspectable public var isFontAwesomeCSSCode: Bool = true
+    @IBInspectable public var size: CGFloat = 22.0
+    
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+        useFontAwesome()
+    }
+    
+    public override func prepareForInterfaceBuilder() {
+        useFontAwesome()
+    }
+    
+    private func useFontAwesome() {
+        updateText {
+            for i in 0 ..< numberOfSegments  {
+                if let cssCode = titleForSegment(at: i) {
+                    setTitle(String.fontAwesomeIcon(code: cssCode), forSegmentAt: i)
+                }
+            }
+        }
+        updateFontAttributes { (state, font) in
+            var attributes = titleTextAttributes(for: state) ?? [:]
+            attributes[NSFontAttributeName] = font
+            setTitleTextAttributes(attributes, for: state)
+        }
+    }
+    
+}
+
+extension FontAwesomeSegmentedControl: FontAwesomeTextRepresentable {
+    
+    var isTextCSSCode: Bool {
+        return isFontAwesomeCSSCode
+    }
+    
+    var textSize: CGFloat {
+        return size
+    }
+    
+    static func supportedStates() -> [UIControlState] {
+        if #available(iOS 9.0, *) {
+            return [.normal, .highlighted, .disabled, .focused, .selected, .application, .reserved]
+        } else {
+            return [.normal, .highlighted, .disabled, .selected, .application, .reserved]
+        }
+    }
+    
+}

--- a/FontAwesome/FontAwesomeStateRequirement.swift
+++ b/FontAwesome/FontAwesomeStateRequirement.swift
@@ -1,0 +1,29 @@
+// FontAwesomeStateRequirement.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+protocol FontAwesomeStateRequirement: class {
+    
+    static func supportedStates() -> [UIControlState]
+    
+}

--- a/FontAwesome/FontAwesomeTabBarItem.swift
+++ b/FontAwesome/FontAwesomeTabBarItem.swift
@@ -1,0 +1,62 @@
+// FontAwesomeTabBarItem.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+@IBDesignable public class FontAwesomeTabBarItem: UITabBarItem {
+    
+    @IBInspectable public var iconName: String = "fa-square-o"
+    @IBInspectable public var selectedIconName: String = "fa-square"
+    @IBInspectable public var size: CGFloat = 38.0
+    
+    public override func awakeFromNib() {
+        super.awakeFromNib()
+        useFontAwesomeImage()
+    }
+    
+    public override func prepareForInterfaceBuilder() {
+        useFontAwesomeImage()
+    }
+    
+    private func useFontAwesomeImage() {
+        createImages { (img, index) in
+            if index == 0 {
+                image = img
+            } else {
+                selectedImage = img
+            }
+        }
+    }
+    
+}
+
+extension FontAwesomeTabBarItem: FontAwesomeImageRepresentable {
+    
+    var imageWidth: CGFloat {
+        return size
+    }
+    
+    var imageConfigs: [ImageConfig] {
+        return [(iconName, nil, nil), (selectedIconName, nil, nil)]
+    }
+    
+}

--- a/FontAwesome/FontAwesomeTextRepresentable.swift
+++ b/FontAwesome/FontAwesomeTextRepresentable.swift
@@ -1,0 +1,54 @@
+// FontAwesomeTextRepresentable.swift
+//
+// Copyright (c) 2017 Maik639
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import UIKit
+
+protocol FontAwesomeTextRepresentable: class, FontAwesomeStateRequirement {
+    
+    var textSize: CGFloat { get }
+    var isTextCSSCode: Bool { get }
+
+    func updateText(_ updateTextBlock: () -> ())
+    func updateFontAttributes(forStates stateBlock: (UIControlState, UIFont) -> ())
+    
+}
+
+extension FontAwesomeTextRepresentable {
+    
+    public func updateText(_ updateTextBlock: () -> ()) {
+        guard isTextCSSCode else {
+            return
+        }
+        
+        updateTextBlock()
+    }
+    
+    public func updateFontAttributes(forStates stateBlock: (UIControlState, UIFont) -> ()) {
+        let states = type(of: self).supportedStates()
+        let font = UIFont.fontAwesome(ofSize: textSize)
+        
+        for state in states {
+            stateBlock(state, font)
+        }
+    }
+
+}


### PR DESCRIPTION
I've created some subclasses to use controls like an UISegmentedControl in storyboard with IBDesignable support. You can type in the CSS-Code and the Storyboard will show the correct icon from FontAwesome. Apple does not render UITabBarItem and UIBarButtonItem in storyboard, but they will have the correct appearance at run time. I've only created subclasses of UI-elements that does not support attributed texts.