### PR TITLE
Rename Style to FontAwesomeStyle

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -35,7 +35,7 @@ public struct FontAwesomeConfig {
     public static let fontAspectRatio: CGFloat = 1.28571429
 }
 
-public enum Style: String {
+public enum FontAwesomeStyle: String {
     case solid
     case regular
     case brands
@@ -80,14 +80,14 @@ public extension UIFont {
     ///
     /// - parameter ofSize: The preferred font size.
     /// - returns: A UIFont object of FontAwesome.
-    public class func fontAwesome(ofSize fontSize: CGFloat, style: Style) -> UIFont {
+    public class func fontAwesome(ofSize fontSize: CGFloat, style: FontAwesomeStyle) -> UIFont {
         loadFontAwesome(ofStyle: style)
         return UIFont(name: style.fontName(), size: fontSize)!
     }
 
     /// Loads the FontAwesome font in to memory.
     /// This method should be called when setting icons without using code.
-    public class func loadFontAwesome(ofStyle style: Style) {
+    public class func loadFontAwesome(ofStyle style: FontAwesomeStyle) {
         if !UIFont.fontNames(forFamilyName: style.fontFamilyName()).isEmpty {
             return
         }
@@ -142,7 +142,7 @@ public extension UIImage {
     /// - parameter size: The image size.
     /// - parameter backgroundColor: The background color (optional).
     /// - returns: A string that will appear as icon with FontAwesome
-    public static func fontAwesomeIcon(name: FontAwesome, style: Style, textColor: UIColor, size: CGSize, backgroundColor: UIColor = UIColor.clear, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.clear) -> UIImage {
+    public static func fontAwesomeIcon(name: FontAwesome, style: FontAwesomeStyle, textColor: UIColor, size: CGSize, backgroundColor: UIColor = UIColor.clear, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.clear) -> UIImage {
 
         // Prevent application crash when passing size where width or height is set equal to or less than zero, by clipping width and height to a minimum of 1 pixel.
         var size = size
@@ -181,7 +181,7 @@ public extension UIImage {
     /// - parameter size: The image size.
     /// - parameter backgroundColor: The background color (optional).
     /// - returns: A string that will appear as icon with FontAwesome
-    public static func fontAwesomeIcon(code: String, style: Style, textColor: UIColor, size: CGSize, backgroundColor: UIColor = UIColor.clear, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.clear) -> UIImage? {
+    public static func fontAwesomeIcon(code: String, style: FontAwesomeStyle, textColor: UIColor, size: CGSize, backgroundColor: UIColor = UIColor.clear, borderWidth: CGFloat = 0, borderColor: UIColor = UIColor.clear) -> UIImage? {
         guard let name = String.fontAwesome(code: code) else { return nil }
         return fontAwesomeIcon(name: name, style: style, textColor: textColor, size: size, backgroundColor: backgroundColor, borderWidth: borderWidth, borderColor: borderColor)
     }

--- a/FontAwesome/FontAwesomeBarButtonItem.swift
+++ b/FontAwesome/FontAwesomeBarButtonItem.swift
@@ -66,8 +66,8 @@ extension FontAwesomeBarButtonItem: FontAwesomeTextRepresentable {
         return size
     }
 
-    var fontStyle: Style {
-        return Style(rawValue: styleName) ?? .solid
+    var fontStyle: FontAwesomeStyle {
+        return FontAwesomeStyle(rawValue: styleName) ?? .solid
     }
 
     static func supportedStates() -> [UIControlState] {

--- a/FontAwesome/FontAwesomeImageRepresentable.swift
+++ b/FontAwesome/FontAwesomeImageRepresentable.swift
@@ -24,7 +24,7 @@ import UIKit
 
 protocol FontAwesomeImageRepresentable: class {
 
-    typealias ImageConfig = (cssIconName: String, style: Style, color: UIColor?, backgroundColor: UIColor?)
+    typealias ImageConfig = (cssIconName: String, style: FontAwesomeStyle, color: UIColor?, backgroundColor: UIColor?)
 
     var imageWidth: CGFloat { get }
     var imageConfigs: [ImageConfig] { get }

--- a/FontAwesome/FontAwesomeImageView.swift
+++ b/FontAwesome/FontAwesomeImageView.swift
@@ -53,7 +53,7 @@ extension FontAwesomeImageView: FontAwesomeImageRepresentable {
     }
 
     var imageConfigs: [ImageConfig] {
-        guard let style = Style(rawValue: styleName.lowercased()) else { return [] }
+        guard let style = FontAwesomeStyle(rawValue: styleName.lowercased()) else { return [] }
         return [(cssCode, style, imageColor, imageBackgroundColor)]
     }
 

--- a/FontAwesome/FontAwesomeSegmentedControl.swift
+++ b/FontAwesome/FontAwesomeSegmentedControl.swift
@@ -59,8 +59,8 @@ extension FontAwesomeSegmentedControl: FontAwesomeTextRepresentable {
         return isFontAwesomeCSSCode
     }
 
-    var fontStyle: Style {
-        return Style(rawValue: styleName) ?? .solid
+    var fontStyle: FontAwesomeStyle {
+        return FontAwesomeStyle(rawValue: styleName) ?? .solid
     }
 
     var textSize: CGFloat {

--- a/FontAwesome/FontAwesomeTabBarItem.swift
+++ b/FontAwesome/FontAwesomeTabBarItem.swift
@@ -57,7 +57,7 @@ extension FontAwesomeTabBarItem: FontAwesomeImageRepresentable {
     }
 
     var imageConfigs: [ImageConfig] {
-        guard let style = Style(rawValue: styleName.lowercased()) else { return [] }
+        guard let style = FontAwesomeStyle(rawValue: styleName.lowercased()) else { return [] }
         return [(iconName, style, nil, nil), (selectedIconName, style, nil, nil)]
     }
 

--- a/FontAwesome/FontAwesomeTextRepresentable.swift
+++ b/FontAwesome/FontAwesomeTextRepresentable.swift
@@ -26,7 +26,7 @@ protocol FontAwesomeTextRepresentable: FontAwesomeStateRequirement {
 
     var textSize: CGFloat { get }
     var isTextCSSCode: Bool { get }
-    var fontStyle: Style { get }
+    var fontStyle: FontAwesomeStyle { get }
 
     func updateText(_ updateTextBlock: () -> Void)
     func updateFontAttributes(forStates stateBlock: (UIControlState, UIFont) -> Void)

--- a/FontAwesome/FontAwesomeView.swift
+++ b/FontAwesome/FontAwesomeView.swift
@@ -68,7 +68,7 @@ import UIKit
         super.layoutSubviews()
         self.clipsToBounds = true
         let size = bounds.size.width < bounds.size.height ? bounds.size.width : bounds.size.height
-        let style = Style(rawValue: styleName) ?? .solid
+        let style = FontAwesomeStyle(rawValue: styleName) ?? .solid
         self.iconView.font = UIFont.fontAwesome(ofSize: size, style: style)
         self.iconView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: CGSize(width: bounds.size.width, height: bounds.size.height))
     }


### PR DESCRIPTION
Hi,

In Xcode 10 (beta 5), "Style" is used in UIBarButtonItem class.
We have to change class name for avoiding compile error.

** Error Screenshot **
![image](https://user-images.githubusercontent.com/1206009/43687616-18db3734-9913-11e8-8ff6-88cafd5c1072.png)