### PR TITLE
Bug Fix: Crash if load font regular and solid style

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -92,7 +92,12 @@ public extension UIFont {
             return
         }
 
-        FontLoader.loadFont(style.fontFilename())
+        if style == .solid || style == .regular {
+            FontLoader.loadFont(FontAwesomeStyle.solid.fontFilename())
+            FontLoader.loadFont(FontAwesomeStyle.regular.fontFilename())
+        } else {
+            FontLoader.loadFont(style.fontFilename())
+        }
     }
 }
 


### PR DESCRIPTION
FontAwesome was crashed if load font both regular and solid styles.

<img width="844" alt="2018-08-06 10 31 15" src="https://user-images.githubusercontent.com/1206009/43692841-9f65a4e0-9965-11e8-95ca-3e890e29bc2f.png">


### Crash Source Code

```swift
let starImage = UIImage.fontAwesomeIcon(
    name: .star,
    style: .solid,
    textColor: UIColor.yellow,
    size: CGSize(width: 60, height: 60)
)
let starOImage = UIImage.fontAwesomeIcon(
    name: .star,
    style: FontAwesomeStyle.regular,
    textColor: UIColor.yellow,
    size: CGSize(width: 60, height: 60)
) // crash
```

### Cause of this bug

In my research, checking loaded font logic is wrong: 
```
public class func loadFontAwesome(ofStyle style: FontAwesomeStyle) {
    if !UIFont.fontNames(forFamilyName: style.fontFamilyName()).isEmpty {
        return
    }
    ...
}
```

Style `solid` and `regular` has same `fontFamilyName()` but different `fontName()`.

First load `solid`, and then 'regular', FontAwesome expect "Font-Awesome-5-Free-Regular-400.otf" file was already loaded, but actually it is not loaded.  

