### PR TITLE
Allow usage of Font Awesome Pro fonts

### DIFF
--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -33,19 +33,29 @@ public struct FontAwesomeConfig {
 
     /// Taken from FontAwesome.io's Fixed Width Icon CSS.
     public static let fontAspectRatio: CGFloat = 1.28571429
+
+    /// Whether Font Awesome Pro fonts should be used (not included).
+    ///
+    /// To use Font Awesome Pro fonts, you should add these to your main project and
+    /// make sure they are added to the target and are included in the Info.plist file.
+    public static var useProFonts: Bool = false
 }
 
 public enum FontAwesomeStyle: String {
     case solid
+    /// WARNING: Font Awesome Free doesn't include a Light variant. Using this with Free will fallback to Regular.
+    case light
     case regular
     case brands
 
     func fontName() -> String {
         switch self {
         case .solid:
-            return "FontAwesome5Free-Solid"
+            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProSolid" : "FontAwesome5Free-Solid"
+        case .light:
+            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProLight" : "FontAwesome5Free-Regular"
         case .regular:
-            return "FontAwesome5Free-Regular"
+            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProRegular" : "FontAwesome5Free-Regular"
         case .brands:
             return "FontAwesome5Brands-Regular"
         }
@@ -54,9 +64,11 @@ public enum FontAwesomeStyle: String {
     func fontFilename() -> String {
         switch self {
         case .solid:
-            return "Font Awesome 5 Free-Solid-900"
+            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Solid-900" : "Font Awesome 5 Free-Solid-900"
+        case .light:
+            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Light-300" : "Font Awesome 5 Free-Regular-400"
         case .regular:
-            return "Font Awesome 5 Free-Regular-400"
+            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Regular-400" : "Font Awesome 5 Free-Regular-400"
         case .brands:
             return "Font Awesome 5 Brands-Regular-400"
         }
@@ -67,8 +79,9 @@ public enum FontAwesomeStyle: String {
         case .brands:
             return "Font Awesome 5 Brands"
         case .regular,
+             .light,
              .solid:
-            return "Font Awesome 5 Free"
+            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro" : "Font Awesome 5 Free"
         }
     }
 }

--- a/FontAwesome/FontAwesome.swift
+++ b/FontAwesome/FontAwesome.swift
@@ -38,7 +38,7 @@ public struct FontAwesomeConfig {
     ///
     /// To use Font Awesome Pro fonts, you should add these to your main project and
     /// make sure they are added to the target and are included in the Info.plist file.
-    public static var useProFonts: Bool = false
+    public static var usesProFonts: Bool = false
 }
 
 public enum FontAwesomeStyle: String {
@@ -51,11 +51,11 @@ public enum FontAwesomeStyle: String {
     func fontName() -> String {
         switch self {
         case .solid:
-            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProSolid" : "FontAwesome5Free-Solid"
+            return FontAwesomeConfig.usesProFonts ? "FontAwesome5ProSolid" : "FontAwesome5Free-Solid"
         case .light:
-            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProLight" : "FontAwesome5Free-Regular"
+            return FontAwesomeConfig.usesProFonts ? "FontAwesome5ProLight" : "FontAwesome5Free-Regular"
         case .regular:
-            return FontAwesomeConfig.useProFonts ? "FontAwesome5ProRegular" : "FontAwesome5Free-Regular"
+            return FontAwesomeConfig.usesProFonts ? "FontAwesome5ProRegular" : "FontAwesome5Free-Regular"
         case .brands:
             return "FontAwesome5Brands-Regular"
         }
@@ -64,11 +64,11 @@ public enum FontAwesomeStyle: String {
     func fontFilename() -> String {
         switch self {
         case .solid:
-            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Solid-900" : "Font Awesome 5 Free-Solid-900"
+            return FontAwesomeConfig.usesProFonts ? "Font Awesome 5 Pro-Solid-900" : "Font Awesome 5 Free-Solid-900"
         case .light:
-            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Light-300" : "Font Awesome 5 Free-Regular-400"
+            return FontAwesomeConfig.usesProFonts ? "Font Awesome 5 Pro-Light-300" : "Font Awesome 5 Free-Regular-400"
         case .regular:
-            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro-Regular-400" : "Font Awesome 5 Free-Regular-400"
+            return FontAwesomeConfig.usesProFonts ? "Font Awesome 5 Pro-Regular-400" : "Font Awesome 5 Free-Regular-400"
         case .brands:
             return "Font Awesome 5 Brands-Regular-400"
         }
@@ -81,7 +81,7 @@ public enum FontAwesomeStyle: String {
         case .regular,
              .light,
              .solid:
-            return FontAwesomeConfig.useProFonts ? "Font Awesome 5 Pro" : "Font Awesome 5 Free"
+            return FontAwesomeConfig.usesProFonts ? "Font Awesome 5 Pro" : "Font Awesome 5 Free"
         }
     }
 }


### PR DESCRIPTION
This PR includes functionality to allow using Font Awesome Pro fonts with the FontAwesome.swift package.

Some notes:

- Of course the FA Pro fonts itself cannot be included due to their license. You will have to add these fonts to you app's bundle yourself (and make sure they're correctly set up by adding them to the app's target and including them in the Info.plist).
- Using FA Pro instead of Free is simple: just include the fonts (see previous bullet), and include the code below in your AppDelegate.swift
- I'm of course open to improvements to the implementation (the way I've implemented it now seemed most simple).
- I know FA Free currently doesn't include a Light-variant, so when using the light variant with FA Free, it will fallback to the Regular-variant.

Usage:

In `AppDelegate.swift`:
```
// ...
import FontAwesome_swift // if using Cocoapods

class AppDelegate: UIResponder, UIApplicationDelegate {

  // ...

  func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
    // ...
    FontAwesomeConfig.usesProFonts = true
    // ...
  }

  // ...
}
```